### PR TITLE
ci: fix token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: main
+permissions:
+  contents: read
 on:
   # push trigger required to get coveralls monitoring of default branch
   # pull_request required to get PR coveralls comments

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,5 +1,8 @@
 name: Semantic PR title
 
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/sripwoud/noir-vite-template/security/code-scanning/2](https://github.com/sripwoud/noir-vite-template/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow. The best practice is to apply it at the root level so that all jobs inherit these permissions, except any that override them explicitly. For this workflow, which lints PR titles using `amannn/action-semantic-pull-request@v5`, the minimal required permissions are typically `contents: read` and `pull-requests: write` (to comment or post a check). Locate the beginning of the workflow (after the `name:` and before `on:` or after `on:`), and insert:

```yaml
permissions:
  contents: read
  pull-requests: write
```

No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
